### PR TITLE
Fixed git clone link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ On ubuntu/debian:
 
 ## installation
 
-    $ git clone git@github.com:mcdevs/mark2.git
+    $ git clone https://github.com/mcdevs/mark2.git
     # ln -s /path/to/mark2/mark2 /usr/bin/mark2
 
 Essentially you just need to make sure the 'mark2' executable is in your path.


### PR DESCRIPTION
Made it so it clones using http
to avoid 

> git clone git@github.com:mcdevs/mark2.git
> Cloning into 'mark2'...
> The authenticity of host 'github.com (207.97.227.239)' can't be established.
> RSA key fingerprint is 16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48.
> Are you sure you want to continue connecting (yes/no)? yes
> Warning: Permanently added 'github.com,207.97.227.239' (RSA) to the list of known hosts.
> Permission denied (publickey).
> fatal: The remote end hung up unexpectedly
