### PR TITLE
Backup plugin needs to parse a different format for auto-saving

### DIFF
--- a/user_client.py
+++ b/user_client.py
@@ -486,7 +486,7 @@ class UserClientFactory(ClientFactory):
         users_l = list(self.system_users)
 
         users = []
-        for u in sorted(set(users_l + users_a), key=str.lower):
+        for u in sorted(set(users_l + users_a), key=lambda x: x.lower()):
             users.append((u, u in users_a))
 
         self.ui.set_users(users)


### PR DESCRIPTION
Backup plugin did not work with the current autosave toggle output, tested in the latest FTB Mindcrack 8.2 (based on vanilla 1.4.7) and vanilla 1.5.1.

```
2013-04-01 18:05:56 [INFO] Starting minecraft server version 1.5.1
...
/save-off
2013-04-01 18:06:01 [INFO] Turned off world auto-saving
/save-on
2013-04-01 18:06:07 [INFO] Turned on world auto-saving
```

There was also an issue with attaching to servers. The method user_client.UserClientFactory.server_users sometimes handled unicode and sometimes regular byte strings, so I changed the str.lower to lambda x: x.lower(). There was another occasion in user_server.py that I changed for good measure.

I also removed some unnecessary trailing whitespace.

Thank you for making this wonderful script.
