### PR TITLE
Send Alerts when x+ players are online

### DIFF
--- a/mk2/plugins/alert.py
+++ b/mk2/plugins/alert.py
@@ -2,16 +2,19 @@ import os
 import random
 
 from mk2.plugins import Plugin
+from mk2.events import Hook, StatPlayerCount
 
 
 class Alert(Plugin):
     interval = Plugin.Property(default=200)
     command  = Plugin.Property(default="say {message}")
     path     = Plugin.Property(default="alerts.txt")
+    min_pcount = Plugin.Property(default=0)
     
     messages = []
     
     def setup(self):
+        self.register(self.count_check, StatPlayerCount)
         if self.path and os.path.exists(self.path):
             f = open(self.path, 'r')
             for l in f:
@@ -20,10 +23,17 @@ class Alert(Plugin):
                     self.messages.append(l)
             f.close()
 
+    def count_check(self, event):
+        if event.players_current >= self.min_pcount:
+            self.requirements_met = True
+        else:
+            self.requirements_met = False
+
     def server_started(self, event):
         if self.messages:
             self.repeating_task(self.repeater, self.interval)
 
     def repeater(self, event):
-        self.send_format(self.command, message=random.choice(self.messages))
+        if self.requirements_met:
+            self.send_format(self.command, message=random.choice(self.messages))
 

--- a/mk2/plugins/alert.py
+++ b/mk2/plugins/alert.py
@@ -24,10 +24,7 @@ class Alert(Plugin):
             f.close()
 
     def count_check(self, event):
-        if event.players_current >= self.min_pcount:
-            self.requirements_met = True
-        else:
-            self.requirements_met = False
+        self.requirements_met = event.players_current >= self.min_pcount
 
     def server_started(self, event):
         if self.messages:

--- a/mk2/resources/mark2.default.properties
+++ b/mk2/resources/mark2.default.properties
@@ -116,6 +116,9 @@ plugin.alert.path=alerts.txt
 plugin.alert.interval=200
 plugin.alert.command=say {message}
 
+# Minimum number of players online that are required for alerts to show up 
+plugin.alert.min-pcount=0
+
 
 ###
 # BACKUP


### PR DESCRIPTION
Only send server alerts if more than x players are online.
Reduces console spam, if you want.
Minimum number of players online that are required for alerts to show up
plugin.alert.min-pcount=0
