### PR TITLE
Craftbukkit/Spigot 1.7.2 Support, Simplify Server Started, and Reduce redundancy from shutdown plugin

### DIFF
--- a/mk2/events/server.py
+++ b/mk2/events/server.py
@@ -71,10 +71,6 @@ class ServerStarted(Event):
     the server_started method.
     """
 
-    time = Event.Arg()
-
-#stop
-
 
 class ServerStop(Event):
     """Issue this event to stop the server."""

--- a/mk2/events/server.py
+++ b/mk2/events/server.py
@@ -4,7 +4,7 @@ from . import Event, get_timestamp
 
 # input/output
 output_exp = re.compile(
-        r'(?P<b>\[)?((?:\d{4}-\d{2}-\d{2} )?)(\d{2}:\d{2}:\d{2})(?(b)\]) \[(?:[^/\]]*/)?([A-Z]+)\]:? (.*)')
+        r'\[([\d+:]+) (.*)\]: (.*)')
 
 class ServerInput(Event):
     """Send data to the server's stdin. In plugins, a shortcut
@@ -27,9 +27,9 @@ class ServerOutput(Event):
         m = output_exp.match(self.line)
         if m:
             g = m.groups()
-            self.time = g[1]+g[2]
-            self.level= g[3]
-            self.data = g[4]
+            self.time = g[0]
+            self.level= g[1]
+            self.data = g[2]
         else:
             self.level= "???"
             self.data = self.line.strip()

--- a/mk2/events/server.py
+++ b/mk2/events/server.py
@@ -4,7 +4,7 @@ from . import Event, get_timestamp
 
 # input/output
 output_exp = re.compile(
-        r'\[([\d+:]+) (.*)\]: (.*)')
+        r'^\[(\d{2}\:\d{2}\:\d{2})\s([A-Z]*)\]\:\s(.*)')
 
 class ServerInput(Event):
     """Send data to the server's stdin. In plugins, a shortcut

--- a/mk2/plugins/shutdown.py
+++ b/mk2/plugins/shutdown.py
@@ -55,7 +55,6 @@ class Shutdown(Plugin):
 
     def nice_stop(self, respawn, kill):
         if not kill:
-            self.send('save-all')
             message = self.restart_message if respawn else self.stop_message
             if self.kick_mode == 'all':
                 for player in self.players:

--- a/mk2/services/process.py
+++ b/mk2/services/process.py
@@ -103,7 +103,7 @@ class Process(Plugin):
         self.stat_process.start(self.parent.config['java.ps.interval'])
 
     def _server_started(self, e):
-        self.parent.events.dispatch(events.ServerStarted(time=e.match.group(1)))
+        self.parent.events.dispatch(events.ServerStarted())
 
     @defer.inlineCallbacks
     def server_stop(self, e):


### PR DESCRIPTION
1.7.2 Support: This will eventually have to be done another way, too many different output expressions (1.6.4 and below, vanilla 1.7.2, craftbukkit/spigot 1.7.2, and forge servers.)
Simplify ServerStarted: The time it takes to start the server isn't used anywhere else, now it just does simple "Done" Detection (which needs to be cleaned up)
Shutdown plugin edits: /save-all isn't required anymore, since it's done automatically anyways.
